### PR TITLE
Always remove source/pins.cpp

### DIFF
--- a/tmpl/Makefile.tmpl
+++ b/tmpl/Makefile.tmpl
@@ -8,4 +8,4 @@ endif
 .PHONY: all
 
 all:
-	cd jerryscript/targets/mbedos5 && pip install -r tools/requirements.txt && rm -f source/js_encoded.cpp && rm -f source/main.cpp && make BOARD=$(BOARD) EXTRA_SRC="$(EXTRAS_CLEAN)" EXTERN_BUILD_DIR=../../../out/$(BOARD) NO_JS=1
+	cd jerryscript/targets/mbedos5 && pip install -r tools/requirements.txt && rm -f source/js_encoded.cpp && rm -f source/pins.cpp && rm -f source/main.cpp && make BOARD=$(BOARD) EXTRA_SRC="$(EXTRAS_CLEAN)" EXTERN_BUILD_DIR=../../../out/$(BOARD) NO_JS=1


### PR DESCRIPTION
Fixes https://github.com/jerryscript-project/jerryscript/issues/1496

We don't re-generate pins.cpp now when switching targets, so you end up with broken code...

@thegecko 