### PR TITLE
Compile on Windows

### DIFF
--- a/tmpl/Makefile.tmpl
+++ b/tmpl/Makefile.tmpl
@@ -8,4 +8,8 @@ endif
 .PHONY: all
 
 all:
+ifeq ($(OS),Windows_NT)
+	cd jerryscript/targets/mbedos5 && pip install -r tools/requirements.txt && cmd //C del source/js_encoded.cpp && cmd //C del source/pins.cpp && cmd //C del source/main.cpp && make BOARD=$(BOARD) EXTRA_SRC="$(EXTRAS_CLEAN)" EXTERN_BUILD_DIR=../../../out/$(BOARD) NO_JS=1
+else
 	cd jerryscript/targets/mbedos5 && pip install -r tools/requirements.txt && rm -f source/js_encoded.cpp && rm -f source/pins.cpp && rm -f source/main.cpp && make BOARD=$(BOARD) EXTRA_SRC="$(EXTRAS_CLEAN)" EXTERN_BUILD_DIR=../../../out/$(BOARD) NO_JS=1
+endif


### PR DESCRIPTION
@thegecko 

Tested on:

* Windows 7 (via cmd.exe)
* Windows 7 (via Git bash / Cygwin)
* macOS

To build with cmd.exe we also needs https://github.com/jerryscript-project/jerryscript/pull/1522.

Requirements for building on Windows:

* All mbed CLI dependencies - including Python and the ARM cross-compiler - in your PATH.
* Recent version of node.js and npm - also in your PATH.
* [GNU Make](http://gnuwin32.sourceforge.net/packages/make.htm) in your PATH.