### PR TITLE
Fix stack size to 8192, as the macro is gone in RTX5

### DIFF
--- a/tmpl/main.cpp.tmpl
+++ b/tmpl/main.cpp.tmpl
@@ -43,7 +43,7 @@ void js_main() {
   jsmbed_js_launch();
 }
 
-rtos::Thread jsThread(osPriorityNormal, DEFAULT_STACK_SIZE*2);
+rtos::Thread jsThread(osPriorityNormal, 8192);
 
 int main() {
 #ifndef JSMBED_USE_RAW_SERIAL


### PR DESCRIPTION
@thegecko 

Prep for updating Jerry to mbed OS 5.5